### PR TITLE
Removing dependencies: []

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,4 +15,3 @@ galaxy_info:
                           - squeeze
         categories:
                 - database
-dependecies: []


### PR DESCRIPTION
May cause an issue while installing Monasca Using Ansible-playbook
Removing 'dependencies' allows you to continue the execution of Ansible-playbook